### PR TITLE
Should be underscores

### DIFF
--- a/ltunify.c
+++ b/ltunify.c
@@ -1214,7 +1214,7 @@ int open_hidraw(void) {
 			}
 			if (access("/sys/module/hid_logitech_dj", F_OK)) {
 				fprintf(stderr, "Driver is not loaded, try:"
-						"   sudo modprobe hid-logitech-dj\n");
+						"   sudo modprobe hid_logitech_dj\n");
 			}
 		}
 	}


### PR DESCRIPTION
modprobe hid-logitech-dj should have underscores, not dashes